### PR TITLE
Faster method of checking if elements are attached to the DOM (#460359)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,8 @@ function MasonryMixin() {
 
             diffDomChildren: function() {
                 var oldChildren = this.domChildren.filter(function(element) {
-                    return document.body.contains(element);
+                    // take only elements attached to DOM (aka the parent is the masonry container, not null)
+                    return element.parentNode;
                 });
                 var newChildren = this.getNewDomChildren();
 


### PR DESCRIPTION
based on the safe assumption that the parent will always be null or masonryContainer